### PR TITLE
Improve "time to first byte"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,21 @@ async function main() {
     databaseName: "sampledb",
   });
 
-  const selectStream = await glueTable.selectObjectContent({
-    // Bucket: "BucketIsOptionalAndNotUsed",
-    // Key: "KeyIsOptionalAndNotUsed",
-    // ..otherwise the interface is the same.
-    ExpressionType: "SQL",
-    InputSerialization: { CSV: {} },
-    OutputSerialization: { JSON: {} },
-    Expression: "SELECT * FROM S3Object LIMIT 2",
-  });
-
-  selectStream.on("data", chunk => {
-    if (chunk.Records && chunk.Records.Payload) process.stdout.write(Buffer.from(chunk.Records.Payload).toString());
-  });
+  const selectStream = await glueTable.selectObjectContent(
+    {
+      // Bucket: "BucketIsOptionalAndNotUsed",
+      // Key: "KeyIsOptionalAndNotUsed",
+      // ..otherwise the interface is the same.
+      ExpressionType: "SQL",
+      InputSerialization: { CSV: {} },
+      OutputSerialization: { JSON: {} },
+      Expression: "SELECT * FROM S3Object LIMIT 2",
+    },
+    chunk => {
+      if (chunk.Records && chunk.Records.Payload) process.stdout.write(Buffer.from(chunk.Records.Payload).toString());
+    },
+    () => console.log("Stream end"),
+  );
 }
 
 main().catch(err => console.log(err));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dforsber/s3-selectable",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "S3 Select over Glue Table",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",


### PR DESCRIPTION
Set handlers for each stream separately by passing them via the API. This improves the "time to first byte", as the merged stream returns only after all streams have been created.